### PR TITLE
Allow setting both DTR and RTS with one command

### DIFF
--- a/firmware/app/usb2dualuart/ftdi/usbd_ftdi.c
+++ b/firmware/app/usb2dualuart/ftdi/usbd_ftdi.c
@@ -50,11 +50,7 @@
 #define SIO_XON_XOFF_HS (0x4 << 8)
 
 #define SIO_SET_DTR_MASK 0x1
-#define SIO_SET_DTR_HIGH (1 | (SIO_SET_DTR_MASK << 8))
-#define SIO_SET_DTR_LOW (0 | (SIO_SET_DTR_MASK << 8))
 #define SIO_SET_RTS_MASK 0x2
-#define SIO_SET_RTS_HIGH (2 | (SIO_SET_RTS_MASK << 8))
-#define SIO_SET_RTS_LOW (0 | (SIO_SET_RTS_MASK << 8))
 
 #define SIO_RTS_CTS_HS (0x1 << 8)
 
@@ -130,25 +126,11 @@ static int ftdi_vendor_request_handler(struct usb_setup_packet *pSetup,
 
       break;
     case SIO_SET_MODEM_CTRL_REQUEST:
-      switch (pSetup->wValue) {
-        case SIO_SET_DTR_HIGH:
-          // LOG_D("DTR 1\r\n");
-          usbd_ftdi_set_dtr(_epid, true);
-          break;
-        case SIO_SET_DTR_LOW:
-          // LOG_D("DTR 0\r\n");
-          usbd_ftdi_set_dtr(_epid, false);
-          break;
-        case SIO_SET_RTS_HIGH:
-          // LOG_D("RTS 1\r\n");
-          usbd_ftdi_set_rts(_epid, true);
-          break;
-        case SIO_SET_RTS_LOW:
-          // LOG_D("RTS 0\r\n");
-          usbd_ftdi_set_rts(_epid, false);
-          break;
-        default:
-          break;
+      if (pSetup->wValue & (SIO_SET_DTR_MASK << 8)) {
+        usbd_ftdi_set_dtr(_epid, pSetup->wValue & SIO_SET_DTR_MASK);
+      }
+      if (pSetup->wValue & (SIO_SET_RTS_MASK << 8)) {
+        usbd_ftdi_set_rts(_epid, pSetup->wValue & SIO_SET_RTS_MASK);
       }
       break;
     case SIO_SET_FLOW_CTRL_REQUEST:

--- a/firmware/app/usb2uartjtag/usbd_ftdi.c
+++ b/firmware/app/usb2uartjtag/usbd_ftdi.c
@@ -60,11 +60,7 @@ static void usbd_ftdi_reset(void)
 #define SIO_XON_XOFF_HS (0x4 << 8)
 
 #define SIO_SET_DTR_MASK 0x1
-#define SIO_SET_DTR_HIGH ( 1 | ( SIO_SET_DTR_MASK  << 8))
-#define SIO_SET_DTR_LOW  ( 0 | ( SIO_SET_DTR_MASK  << 8))
 #define SIO_SET_RTS_MASK 0x2
-#define SIO_SET_RTS_HIGH ( 2 | ( SIO_SET_RTS_MASK << 8 ))
-#define SIO_SET_RTS_LOW ( 0 | ( SIO_SET_RTS_MASK << 8 ))
 
 #define SIO_RTS_CTS_HS (0x1 << 8)
 
@@ -113,26 +109,12 @@ static int ftdi_vendor_request_handler(struct usb_setup_packet *pSetup,uint8_t *
 			break;
 
 		case SIO_SET_MODEM_CTRL_REQUEST:
-			if(pSetup->wValue == SIO_SET_DTR_HIGH)
-			{
-				//USBD_LOG("DTR 1\r\n");
-				usbd_ftdi_set_dtr(true);
+			if (pSetup->wValue & (SIO_SET_DTR_MASK << 8)) {
+				usbd_ftdi_set_dtr(pSetup->wValue & SIO_SET_DTR_MASK);
 			}
-			else if(pSetup->wValue == SIO_SET_DTR_LOW)
-			{
-				//USBD_LOG("DTR 0\r\n");
-				usbd_ftdi_set_dtr(false);
+			if (pSetup->wValue & (SIO_SET_RTS_MASK << 8)) {
+				usbd_ftdi_set_rts(pSetup->wValue & SIO_SET_RTS_MASK);
 			}
-			else if(pSetup->wValue == SIO_SET_RTS_HIGH)
-			{
-				//USBD_LOG("RTS 1\r\n");
-				usbd_ftdi_set_rts(true);
-			}
-			else if(pSetup->wValue == SIO_SET_RTS_LOW)
-			{
-				//USBD_LOG("RTS 0\r\n");
-				usbd_ftdi_set_rts(false);
-			}			
 			break;
 		case SIO_SET_FLOW_CTRL_REQUEST:
 


### PR DESCRIPTION
Separate bit masks are used to control the DTR and RTS signals, so both can be set in the same modem control command. Linux does this, especially when using the TIOCMSET ioctl.